### PR TITLE
Use envsubst lib to allow expressions in replacement

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"github.com/a8m/envsubst"
 )
 
 // type Files []string
@@ -64,13 +65,11 @@ var rootCmd = &cobra.Command{
 }
 
 func expandEnv(filePath string) {
-	content, err := ioutil.ReadFile(filePath)
+	newContent, err := envsubst.ReadFile(filePath)
 
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	newContent := os.ExpandEnv(string(content))
 
 	err = ioutil.WriteFile(filePath, []byte(newContent), 0777)
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/hydeenoble/helm-env
 go 1.16
 
 require (
+	github.com/a8m/envsubst v1.3.0 // indirect
 	github.com/spf13/cobra v1.2.1 // indirect
 	github.com/spf13/viper v1.8.1 // indirect
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/a8m/envsubst v1.3.0 h1:GmXKmVssap0YtlU3E230W98RWtWCyIZzjtf1apWWyAg=
+github.com/a8m/envsubst v1.3.0/go.mod h1:MVUTQNGQ3tsjOOtKCNd+fl8RzhsXcDvvAEzkhGtlsbY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
- This is the list of expressions: https://github.com/a8m/envsubst#docs
- This was tested locally using the binary `helm-subenv` not as a helm plugin